### PR TITLE
24 add controller trait to can controller struct

### DIFF
--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -23,6 +23,7 @@ rp-pico = "0.9.0"
 rp2040-boot2 = "0.3.0"
 embedded-can = "0.4.1"
 bytes = { version = "1.6.0", default-features = false }
+portable-atomic = { version = "1.8.0", features = ["critical-section"] }
 log = "0.4.21"
 usb-device = "0.3.2"
 usbd-serial = "0.2.2"

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -13,7 +13,7 @@ use core::fmt::Write;
 use embedded_can::{Id, StandardId};
 use embedded_hal::delay::DelayNs;
 use fugit::RateExtU32;
-use mcp2517::can::Controller;
+use mcp2517::can::{CanController, MCP2517};
 use mcp2517::config::{
     BitRateConfig, ClockConfiguration, ClockOutputDivisor, Configuration, FifoConfiguration, PLLSetting, RequestMode,
     SystemClockDivisor,
@@ -93,7 +93,7 @@ fn main() -> ! {
     )
     .unwrap();
 
-    let mut can_controller: Controller<_, _, SystemClock> = Controller::new(spi, pin_cs);
+    let mut can_controller: MCP2517<_, _, SystemClock> = MCP2517::new(spi, pin_cs);
 
     // Setup clk config
     let clk_config = ClockConfiguration {

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![no_main]
+#![allow(static_mut_refs)]
 extern crate alloc;
 
 pub mod clock;

--- a/src/can.rs
+++ b/src/can.rs
@@ -96,7 +96,7 @@ pub struct MCP2517<B: Transfer<u8>, CS: OutputPin, CLK: Clock> {
 
 /// Trait for CAN controller
 pub trait CanController {
-    type Error: Mcp2517Error;
+    type Error;
 
     /// Transmit CAN message
     fn transmit<const L: usize, T: MessageType<L>>(&mut self, message: &TxMessage<T, L>) -> Result<(), Self::Error>;

--- a/src/can.rs
+++ b/src/can.rs
@@ -25,8 +25,6 @@ const FIFO_RX_INDEX: u8 = 1;
 /// FIFO index for transmitting CAN messages
 const FIFO_TX_INDEX: u8 = 2;
 
-pub trait Mcp2517Error {}
-
 /// General SPI Errors
 #[derive(Debug, PartialEq)]
 pub enum BusError<B, CS> {
@@ -67,8 +65,6 @@ pub enum Error<B, CS> {
     /// Payload buffer length not a multiple of 4 bytes
     InvalidBufferSize(usize),
 }
-
-impl<B, CS> Mcp2517Error for Error<B, CS> {}
 
 impl<B, CS> From<BusError<B, CS>> for Error<B, CS> {
     fn from(value: BusError<B, CS>) -> Self {

--- a/src/can.rs
+++ b/src/can.rs
@@ -99,7 +99,7 @@ pub trait CanController {
 
     /// Receive CAN message
     fn receive<const L: usize>(&mut self, data: &mut [u8; L]) -> Result<(), Self::Error>;
-
+    /// Set corresponding filter and mask registers
     fn set_filter_object(&mut self, filter: Filter) -> Result<(), Self::Error>;
 }
 

--- a/src/tests/can.rs
+++ b/src/tests/can.rs
@@ -1,4 +1,5 @@
-use crate::can::{BusError, ConfigError, Controller, Error};
+use crate::can::CanController;
+use crate::can::{BusError, ConfigError, Error, MCP2517};
 use crate::config::{
     BitRateConfig, ClockConfiguration, ClockOutputDivisor, Configuration, FifoConfiguration, PLLSetting, PayloadSize,
     RequestMode, RetransmissionAttempts, SystemClockDivisor,
@@ -112,7 +113,7 @@ fn test_configure_correct() {
     pin_cs.expect_set_low().times(14).return_const(Ok(()));
     pin_cs.expect_set_high().times(14).return_const(Ok(()));
 
-    let mut controller = Controller::new(bus, pin_cs);
+    let mut controller = MCP2517::new(bus, pin_cs);
     controller
         .configure(
             &Configuration {
@@ -168,7 +169,7 @@ fn test_configure_mode_timeout() {
     pin_cs.expect_set_low().times(3).return_const(Ok(()));
     pin_cs.expect_set_high().times(3).return_const(Ok(()));
 
-    let mut controller = Controller::new(bus, pin_cs);
+    let mut controller = MCP2517::new(bus, pin_cs);
     assert_eq!(
         ConfigError::ConfigurationModeTimeout,
         controller.configure(&Configuration::default(), &clock).unwrap_err()
@@ -676,7 +677,7 @@ fn test_request_mode_timeout() {
     pin_cs.expect_set_low().times(15).return_const(Ok(()));
     pin_cs.expect_set_high().times(15).return_const(Ok(()));
 
-    let mut controller = Controller::new(bus, pin_cs);
+    let mut controller = MCP2517::new(bus, pin_cs);
     assert_eq!(
         ConfigError::RequestModeTimeout,
         controller.configure(&Configuration::default(), &clock).unwrap_err()
@@ -947,8 +948,8 @@ pub(crate) struct Mocks {
 }
 
 impl Mocks {
-    pub fn into_controller(self) -> Controller<MockSPIBus, MockPin, TestClock> {
-        Controller::new(self.bus, self.pin_cs)
+    pub fn into_controller(self) -> MCP2517<MockSPIBus, MockPin, TestClock> {
+        MCP2517::new(self.bus, self.pin_cs)
     }
 
     /// Simulates a SPI transfer fault

--- a/src/tests/filter.rs
+++ b/src/tests/filter.rs
@@ -1,3 +1,4 @@
+use crate::can::CanController;
 use crate::filter::Filter;
 use crate::tests::can::Mocks;
 use embedded_can::{ExtendedId, Id, StandardId};


### PR DESCRIPTION
Goal is to use is to be able to easily mock the controller functions (transmit, receive etc.) used in the charger communication task in the BMS.